### PR TITLE
Php 8.4 Desteği

### DIFF
--- a/src/Utils/Helpers.php
+++ b/src/Utils/Helpers.php
@@ -119,7 +119,7 @@ if (!function_exists('curdate')) {
      * @param  string|null $modify
      * @return string
      */
-    function curdate(string $format, string $modify = null): string
+    function curdate(string $format, ?string $modify = null): string
     {
         $date = new DateTime('now', new DateTimeZone('Europe/Istanbul'));
         if ($modify) {


### PR DESCRIPTION
Deprecated: curdate(): Implicitly marking parameter $modify as nullable is deprecated